### PR TITLE
Change return type of -supportedInterfaceOrientations

### DIFF
--- a/Airship/UI/Default/Push/Classes/Shared/UALocationSettingsViewController.m
+++ b/Airship/UI/Default/Push/Classes/Shared/UALocationSettingsViewController.m
@@ -178,7 +178,7 @@
     [self addLocationToData:newLocation];
 }
 
-- (NSUInteger)supportedInterfaceOrientations{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations{
     return UIInterfaceOrientationMaskPortrait;
 }
 


### PR DESCRIPTION
This method's previous result type was provoking a warning. This patch fixes it