### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ ua-ios-pod
 
 ua-ios-pod does the following things:
 
-- Provides a staging area for the UrbanAirship-iOS-SDK podspec (which lives in the Cocoapods Specs repo).
+- Provides a staging area for the UrbanAirship-iOS-SDK podspec (which lives in the CocoaPods Specs repo).
 - Provides a pod sample app PodSample with accompanying podfile.
 
 How to use PodSample:


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
